### PR TITLE
Streamlined Dockerfile

### DIFF
--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -59,22 +59,22 @@ RUN mkdir -p /rapids \
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
-# # Configure
-# RUN source activate shareable_dataframes \
-#     && cmake \
-#     -DBUILD_TESTS=OFF \
-#     -DBUILD_BENCHMARKS=OFF \
-#     -DCMAKE_CUDA_ARCHITECTURES= \
-#     -S /rapids/rapids-examples/shareable-dataframes/cpp \
-#     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
+# Configure
+RUN source activate shareable_dataframes \
+    && cmake \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_BENCHMARKS=OFF \
+    -DCMAKE_CUDA_ARCHITECTURES= \
+    -S /rapids/rapids-examples/shareable-dataframes/cpp \
+    -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
-# # Build
-# RUN source activate shareable_dataframes \
-#     && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+# Build
+RUN source activate shareable_dataframes \
+    && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
-# # Install (default install to `/usr/local/{include|lib}` prefix)
-# RUN source activate shareable_dataframes \
-#     && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+# Install (default install to `/usr/local/{include|lib}` prefix)
+RUN source activate shareable_dataframes \
+    && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
 # # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
 # RUN cp /usr/local/lib/libshareable_dataframe.so /conda/envs/shareable_dataframes/lib/.

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -51,25 +51,17 @@ RUN wget \
     && rm -f Miniconda3-latest-Linux-x86_64.sh \
     && conda init bash
 
-# Install CMake
-RUN cd /tmp \
- && curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" -o /tmp/cmake-$CMAKE_VERSION.tar.gz \
- && tar -xvzf /tmp/cmake-$CMAKE_VERSION.tar.gz && cd /tmp/cmake-$CMAKE_VERSION \
- && /tmp/cmake-$CMAKE_VERSION/bootstrap \
-    --system-curl \
-    --parallel=${PARALLEL_LEVEL} \
- && make install -j${PARALLEL_LEVEL} \
- && cd /tmp && rm -rf /tmp/cmake-$CMAKE_VERSION*
-
 # checkout the repo inside the container making it more portable
 RUN mkdir -p /rapids \
- && git clone https://github.com/jdye64/rapids-examples.git /rapids/rapids-examples
+ && git clone https://github.com/jdye64/rapids-examples.git /rapids/rapids-examples \
+ && git checkout rapids-devel-base
 
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
 # Configure
-RUN cmake \
+RUN conda activate shareable_dataframes \
+     && cmake \
     -DBUILD_TESTS=OFF \
     -DBUILD_BENCHMARKS=OFF \
     -DCMAKE_CUDA_ARCHITECTURES= \
@@ -77,10 +69,12 @@ RUN cmake \
     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
 # Build
-RUN cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+RUN conda activate shareable_dataframes \
+    && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
 # Install (default install to `/usr/local/{include|lib}` prefix)
-RUN cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+RUN conda activate shareable_dataframes \
+    && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
 # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
 RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -59,25 +59,25 @@ RUN mkdir -p /rapids \
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
-# Configure
-RUN source activate shareable_dataframes \
-    && cmake \
-    -DBUILD_TESTS=OFF \
-    -DBUILD_BENCHMARKS=OFF \
-    -DCMAKE_CUDA_ARCHITECTURES= \
-    -S /rapids/rapids-examples/shareable-dataframes/cpp \
-    -B /rapids/rapids-examples/shareable-dataframes/cpp/build
+# # Configure
+# RUN source activate shareable_dataframes \
+#     && cmake \
+#     -DBUILD_TESTS=OFF \
+#     -DBUILD_BENCHMARKS=OFF \
+#     -DCMAKE_CUDA_ARCHITECTURES= \
+#     -S /rapids/rapids-examples/shareable-dataframes/cpp \
+#     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
-# Build
-RUN source activate shareable_dataframes \
-    && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+# # Build
+# RUN source activate shareable_dataframes \
+#     && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
-# Install (default install to `/usr/local/{include|lib}` prefix)
-RUN source activate shareable_dataframes \
-    && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+# # Install (default install to `/usr/local/{include|lib}` prefix)
+# RUN source activate shareable_dataframes \
+#     && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
-# Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
-RUN cp /usr/local/lib/libshareable_dataframe.so /conda/envs/shareable_dataframes/lib/.
+# # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
+# RUN cp /usr/local/lib/libshareable_dataframe.so /conda/envs/shareable_dataframes/lib/.
 
-SHELL ["/bin/bash", "-l"]
-CMD ["/bin/bash", "-l"]
+# SHELL ["/bin/bash", "-l"]
+# CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -59,25 +59,25 @@ RUN mkdir -p /rapids \
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
-# # Configure
-# RUN source activate shareable_dataframes \
-#     && cmake \
-#     -DBUILD_TESTS=OFF \
-#     -DBUILD_BENCHMARKS=OFF \
-#     -DCMAKE_CUDA_ARCHITECTURES= \
-#     -S /rapids/rapids-examples/shareable-dataframes/cpp \
-#     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
+# Configure
+RUN source activate shareable_dataframes \
+    && cmake \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_BENCHMARKS=OFF \
+    -DCMAKE_CUDA_ARCHITECTURES="ALL" \
+    -S /rapids/rapids-examples/shareable-dataframes/cpp \
+    -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
-# # Build
-# RUN source activate shareable_dataframes \
-#     && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+# Build
+RUN source activate shareable_dataframes \
+    && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
-# # Install (default install to `/usr/local/{include|lib}` prefix)
-# RUN source activate shareable_dataframes \
-#     && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+# Install (default install to `/usr/local/{include|lib}` prefix)
+RUN source activate shareable_dataframes \
+    && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
-# # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
-# RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
+# Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
+RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
 
-# SHELL ["/bin/bash", "-l"]
-# CMD ["/bin/bash", "-l"]
+SHELL ["/bin/bash", "-l"]
+CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -25,7 +25,7 @@ CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
 && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
 && apt update -y \
 && apt install -y \
-   build-essential git wget \
+   build-essential git wget vim\
    gcc-${GCC_VERSION} g++-${GCC_VERSION} \
    # CMake dependencies
    curl libssl-dev libcurl4-openssl-dev zlib1g-dev \
@@ -59,9 +59,6 @@ RUN mkdir -p /rapids \
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
-# # Make all RUN commands run in the context of the `shareable_dataframes` conda environment
-# SHELL ["conda", "run", "-n", "shareable_dataframes", "/bin/bash", "-c"]
-
 # Configure
 RUN source activate shareable_dataframes \
     && cmake \
@@ -71,14 +68,16 @@ RUN source activate shareable_dataframes \
     -S /rapids/rapids-examples/shareable-dataframes/cpp \
     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
-# # Build
-# RUN cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+# Build
+RUN source activate shareable_dataframes \
+    && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
-# # Install (default install to `/usr/local/{include|lib}` prefix)
-# RUN cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+# Install (default install to `/usr/local/{include|lib}` prefix)
+RUN source activate shareable_dataframes \
+    && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
-# # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
-# RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
+# Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
+RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
 
 SHELL ["/bin/bash", "-l"]
 CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -65,6 +65,7 @@ RUN source activate shareable_dataframes \
     -DBUILD_TESTS=OFF \
     -DBUILD_BENCHMARKS=OFF \
     -DCMAKE_CUDA_ARCHITECTURES= \
+    -DCMAKE_INSTALL_PREFIX=/conda/envs/shareable_dataframes \
     -S /rapids/rapids-examples/shareable-dataframes/cpp \
     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
@@ -76,8 +77,5 @@ RUN source activate shareable_dataframes \
 RUN source activate shareable_dataframes \
     && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
-# # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
-# RUN cp /usr/local/lib/libshareable_dataframe.so /conda/envs/shareable_dataframes/lib/.
-
-# SHELL ["/bin/bash", "-l"]
-# CMD ["/bin/bash", "-l"]
+SHELL ["/bin/bash", "-l"]
+CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -59,25 +59,25 @@ RUN mkdir -p /rapids \
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
-# Configure
-RUN source activate shareable_dataframes \
-    && cmake \
-    -DBUILD_TESTS=OFF \
-    -DBUILD_BENCHMARKS=OFF \
-    -DCMAKE_CUDA_ARCHITECTURES= \
-    -S /rapids/rapids-examples/shareable-dataframes/cpp \
-    -B /rapids/rapids-examples/shareable-dataframes/cpp/build
+# # Configure
+# RUN source activate shareable_dataframes \
+#     && cmake \
+#     -DBUILD_TESTS=OFF \
+#     -DBUILD_BENCHMARKS=OFF \
+#     -DCMAKE_CUDA_ARCHITECTURES= \
+#     -S /rapids/rapids-examples/shareable-dataframes/cpp \
+#     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
-# Build
-RUN source activate shareable_dataframes \
-    && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+# # Build
+# RUN source activate shareable_dataframes \
+#     && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
-# Install (default install to `/usr/local/{include|lib}` prefix)
-RUN source activate shareable_dataframes \
-    && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+# # Install (default install to `/usr/local/{include|lib}` prefix)
+# RUN source activate shareable_dataframes \
+#     && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
-# Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
-RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
+# # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
+# RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
 
-SHELL ["/bin/bash", "-l"]
-CMD ["/bin/bash", "-l"]
+# SHELL ["/bin/bash", "-l"]
+# CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -23,7 +23,6 @@ CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
 && apt install -y software-properties-common \
 && add-apt-repository -y ppa:git-core/ppa \
 && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
-&& add-apt-repository ppa:deadsnakes/ppa \
 && apt update -y \
 && apt install -y \
    build-essential git wget \
@@ -32,8 +31,6 @@ CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
    curl libssl-dev libcurl4-openssl-dev zlib1g-dev \
    # cuDF dependencies
    libboost-filesystem-dev \
-   # # Install Python 3.8
-   # python3.8 \
 && apt autoremove -y \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 && update-alternatives \
@@ -46,9 +43,12 @@ ARG CMAKE_VERSION=3.18.5
 # Install miniconda
 RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b -p /conda \
     && rm -f Miniconda3-latest-Linux-x86_64.sh 
+
+ENV PATH=${PATH}:/conda/bin
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
 
 # checkout the repo inside the container making it more portable
 RUN mkdir -p /rapids \
@@ -59,25 +59,26 @@ RUN mkdir -p /rapids \
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
-# Make all RUN commands run in the context of the `shareable_dataframes` conda environment
-SHELL ["conda", "run", "-n", "shareable_dataframes", "/bin/bash", "-c"]
+# # Make all RUN commands run in the context of the `shareable_dataframes` conda environment
+# SHELL ["conda", "run", "-n", "shareable_dataframes", "/bin/bash", "-c"]
 
 # Configure
-RUN cmake \
+RUN source activate shareable_dataframes \
+    && cmake \
     -DBUILD_TESTS=OFF \
     -DBUILD_BENCHMARKS=OFF \
     -DCMAKE_CUDA_ARCHITECTURES= \
     -S /rapids/rapids-examples/shareable-dataframes/cpp \
     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
-# Build
-RUN cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+# # Build
+# RUN cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
-# Install (default install to `/usr/local/{include|lib}` prefix)
-RUN cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+# # Install (default install to `/usr/local/{include|lib}` prefix)
+# RUN cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
-# Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
-RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
+# # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
+# RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
 
 SHELL ["/bin/bash", "-l"]
 CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -64,7 +64,7 @@ RUN source activate shareable_dataframes \
     && cmake \
     -DBUILD_TESTS=OFF \
     -DBUILD_BENCHMARKS=OFF \
-    -DCMAKE_CUDA_ARCHITECTURES="ALL" \
+    -DCMAKE_CUDA_ARCHITECTURES= \
     -S /rapids/rapids-examples/shareable-dataframes/cpp \
     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
@@ -77,7 +77,7 @@ RUN source activate shareable_dataframes \
     && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
 # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
-RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.
+RUN cp /usr/local/lib/libshareable_dataframe.so /conda/envs/shareable_dataframes/lib/.
 
 SHELL ["/bin/bash", "-l"]
 CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -48,20 +48,22 @@ RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && mkdir /root/.conda \
     && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh \
-    && conda init bash
+    && rm -f Miniconda3-latest-Linux-x86_64.sh 
 
 # checkout the repo inside the container making it more portable
 RUN mkdir -p /rapids \
  && git clone https://github.com/jdye64/rapids-examples.git /rapids/rapids-examples \
+ && cd /rapids/rapids-examples \
  && git checkout rapids-devel-base
 
 # Create shareable_dataframes conda environment
 RUN conda env create -f /rapids/rapids-examples/shareable-dataframes/conda/shareable_dataframes.yml --name shareable_dataframes
 
+# Make all RUN commands run in the context of the `shareable_dataframes` conda environment
+SHELL ["conda", "run", "-n", "shareable_dataframes", "/bin/bash", "-c"]
+
 # Configure
-RUN conda activate shareable_dataframes \
-     && cmake \
+RUN cmake \
     -DBUILD_TESTS=OFF \
     -DBUILD_BENCHMARKS=OFF \
     -DCMAKE_CUDA_ARCHITECTURES= \
@@ -69,12 +71,10 @@ RUN conda activate shareable_dataframes \
     -B /rapids/rapids-examples/shareable-dataframes/cpp/build
 
 # Build
-RUN conda activate shareable_dataframes \
-    && cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
+RUN cmake --build /rapids/rapids-examples/shareable-dataframes/cpp/build -j${PARALLEL_LEVEL} -v
 
 # Install (default install to `/usr/local/{include|lib}` prefix)
-RUN conda activate shareable_dataframes \
-    && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
+RUN cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
 # Since the default install location is /usr/local/lib. Lets copy to the anaconda env to make things easier for Python development
 RUN cp /usr/local/lib/libshareable_dataframe.so /root/miniconda3/envs/shareable_dataframes/lib/.

--- a/shareable-dataframes/Dockerfile
+++ b/shareable-dataframes/Dockerfile
@@ -77,5 +77,10 @@ RUN source activate shareable_dataframes \
 RUN source activate shareable_dataframes \
     && cmake --install /rapids/rapids-examples/shareable-dataframes/cpp/build -v
 
+# Build the python code
+RUN source activate shareable_dataframes \
+    && cd /rapids/rapids-examples/shareable-dataframes/python \
+    && python setup.py build install
+
 SHELL ["/bin/bash", "-l"]
 CMD ["/bin/bash", "-l"]

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -130,7 +130,7 @@ if(BUILD_SHAREABLE_DATAFRAME)
   target_include_directories(shareable_dataframe PRIVATE 
                             "${CMAKE_CURRENT_SOURCE_DIR}/include"
                             "${LIBCUDACXX_INCLUDE_DIR}"
-                            "${LIBCXX_INCLUDE_DIR}"
+                            # "${LIBCXX_INCLUDE_DIR}"
                             )
 
   # Add Conda library paths if specified

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -92,7 +92,7 @@ CPMFindPackage(NAME  cudf
                         "BUILD_BENCHMARKS OFF"
                         "ARROW_STATIC_LIB ON"
                         "JITIFY_USE_CACHE ON"
-                        "CUDA_STATIC_RUNTIME ON"
+                        "CUDA_STATIC_RUNTIME OFF"
                         "DISABLE_DEPRECATION_WARNING ON"
                         "AUTO_DETECT_CUDA_ARCHITECTURES ON"
     )

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -25,16 +25,6 @@ elseif(DEFINED ENV{CONDA_PREFIX})
     message(VERBOSE "CUDF: Conda environment detected, CMAKE_PREFIX_PATH set to: ${CMAKE_PREFIX_PATH}")
 endif()
 
-# Add Conda library paths if specified
-if(CONDA_LINK_DIRS)
-    target_link_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_LINK_DIRS}>")
-endif()
-
-# Add Conda include paths if specified
-if(CONDA_INCLUDE_DIRS)
-    target_include_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_INCLUDE_DIRS}>")
-endif()
-
 #################################################################################################
 # - CPM -----------------------------------------------------------------------------------------
 
@@ -123,6 +113,17 @@ if(BUILD_SHAREABLE_DATAFRAME)
   target_link_libraries(shareable_dataframe
                         cudf::cudf
                         )
+
+  # Add Conda library paths if specified
+  if(CONDA_LINK_DIRS)
+    target_link_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_LINK_DIRS}>")
+  endif()
+
+  # Add Conda include paths if specified
+  if(CONDA_INCLUDE_DIRS)
+    target_include_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_INCLUDE_DIRS}>")
+  endif()
+  
 endif()
 
 

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -82,20 +82,20 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 ####################################################################################################
 # - cudf -------------------------------------------------------------------------------------------
 
-# CPMFindPackage(NAME  cudf
-#         VERSION         "0.19.0"
-#         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-#         GIT_TAG         branch-0.19
-#         GIT_SHALLOW     TRUE
-#         SOURCE_SUBDIR   cpp
-#         OPTIONS         "BUILD_TESTS OFF"
-#                         "BUILD_BENCHMARKS OFF"
-#                         "ARROW_STATIC_LIB ON"
-#                         "JITIFY_USE_CACHE ON"
-#                         "CUDA_STATIC_RUNTIME ON"
-#                         "DISABLE_DEPRECATION_WARNING ON"
-#                         "AUTO_DETECT_CUDA_ARCHITECTURES ON"
-#     )
+CPMFindPackage(NAME  cudf
+        VERSION         "0.19.0"
+        GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
+        GIT_TAG         branch-0.19
+        GIT_SHALLOW     TRUE
+        SOURCE_SUBDIR   cpp
+        OPTIONS         "BUILD_TESTS OFF"
+                        "BUILD_BENCHMARKS OFF"
+                        "ARROW_STATIC_LIB ON"
+                        "JITIFY_USE_CACHE ON"
+                        "CUDA_STATIC_RUNTIME ON"
+                        "DISABLE_DEPRECATION_WARNING ON"
+                        "AUTO_DETECT_CUDA_ARCHITECTURES ON"
+    )
 
 ######################################################################################################
 # - shareable_dataframes -----------------------------------------------------------------------------
@@ -110,20 +110,19 @@ if(BUILD_SHAREABLE_DATAFRAME)
                             "${CMAKE_CURRENT_SOURCE_DIR}/include"
                             )
 
-  # target_link_libraries(shareable_dataframe
-  #                       cudf::cudf
-  #                       )
-
   # Add Conda library paths if specified
   if(CONDA_LINK_DIRS)
     target_link_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_LINK_DIRS}>")
-    target_link_libraries(shareable_dataframe cudf)
   endif()
 
   # Add Conda include paths if specified
   if(CONDA_INCLUDE_DIRS)
     target_include_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_INCLUDE_DIRS}>")
   endif()
+
+  target_link_libraries(shareable_dataframe
+                        cudf::cudf
+                        )
 
 endif()
 
@@ -132,9 +131,9 @@ endif()
 # ###################################################################################################
 # # - library paths ---------------------------------------------------------------------------------
 
-link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
-                 "${CMAKE_BINARY_DIR}/lib"
-                 "${CMAKE_BINARY_DIR}")
+# link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
+#                  "${CMAKE_BINARY_DIR}/lib"
+#                  "${CMAKE_BINARY_DIR}")
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -83,7 +83,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 # - cudf -------------------------------------------------------------------------------------------
 
 CPMFindPackage(NAME  cudf
-        VERSION         "0.19"
+        VERSION         "0.19.0"
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
         GIT_TAG         branch-0.19
         GIT_SHALLOW     TRUE
@@ -123,7 +123,7 @@ if(BUILD_SHAREABLE_DATAFRAME)
   if(CONDA_INCLUDE_DIRS)
     target_include_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_INCLUDE_DIRS}>")
   endif()
-  
+
 endif()
 
 
@@ -134,10 +134,6 @@ endif()
 link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
                  "${CMAKE_BINARY_DIR}/lib"
                  "${CMAKE_BINARY_DIR}")
-
-if(CONDA_LINK_DIRS)
-    link_directories("${CONDA_LINK_DIRS}")
-endif(CONDA_LINK_DIRS)
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -171,8 +171,8 @@ install(TARGETS shareable_dataframe
         DESTINATION lib
         EXPORT shareable_dataframes-targets)
 
-install(DIRECTORY
-            ${CUDF_SOURCE_DIR}/include
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# install(DIRECTORY
+#             ${CUDF_SOURCE_DIR}/include
+#         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include(CMakePackageConfigHelpers)

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -98,6 +98,27 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 #     )
 
 ######################################################################################################
+# - libcudacxx ---------------------------------------------------------------------------------------
+
+function(find_and_configure_libcudacxx VERSION)
+    CPMFindPackage(NAME     libcudacxx
+        VERSION             ${VERSION}
+        GIT_REPOSITORY      https://github.com/NVIDIA/libcudacxx.git
+        GIT_TAG             ${VERSION}
+        GIT_SHALLOW         TRUE
+        DOWNLOAD_ONLY       TRUE
+    )
+    set(LIBCUDACXX_DIR "${libcudacxx_SOURCE_DIR}" PARENT_SCOPE)
+    set(LIBCUDACXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/include" PARENT_SCOPE)
+    set(LIBCXX_DIR "${libcudacxx_SOURCE_DIR}/libcxx" PARENT_SCOPE)
+    set(LIBCXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/libcxx/include" PARENT_SCOPE)
+endfunction()
+
+set(CUDF_MIN_VERSION_libcudacxx 1.4.0)
+
+find_and_configure_libcudacxx(${CUDF_MIN_VERSION_libcudacxx})
+
+######################################################################################################
 # - shareable_dataframes -----------------------------------------------------------------------------
 
 if(BUILD_SHAREABLE_DATAFRAME)

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -125,12 +125,12 @@ if(BUILD_SHAREABLE_DATAFRAME)
   message(STATUS "Building ${BUILD_SHAREABLE_DATAFRAME} example")
 
   # Create the `shareable_dataframe` shared object
-  add_library(shareable_dataframe "src/kernel_wrapper.cu")
+  add_library(shareable_dataframe SHARED
+              "src/kernel_wrapper.cu")
 
   target_include_directories(shareable_dataframe PRIVATE 
                             "${CMAKE_CURRENT_SOURCE_DIR}/include"
                             "${LIBCUDACXX_INCLUDE_DIR}"
-                            # "${LIBCXX_INCLUDE_DIR}"
                             )
 
   # Add Conda library paths if specified

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -10,6 +10,31 @@ endif(NOT CMAKE_CUDA_COMPILER)
 option(BUILD_SHAREABLE_DATAFRAME "Build the strings_udf project" ON)
 set(SHAREABLE_DATAFRAME "shareable-dataframes")
 
+###################################################################################################
+# - conda environment -----------------------------------------------------------------------------
+
+if("$ENV{CONDA_BUILD}" STREQUAL "1")
+    set(CMAKE_PREFIX_PATH "$ENV{BUILD_PREFIX};$ENV{PREFIX};${CMAKE_PREFIX_PATH}")
+    set(CONDA_INCLUDE_DIRS "$ENV{BUILD_PREFIX}/include" "$ENV{PREFIX}/include")
+    set(CONDA_LINK_DIRS "$ENV{BUILD_PREFIX}/lib" "$ENV{PREFIX}/lib")
+    message(VERBOSE "CUDF: Conda build detected, CMAKE_PREFIX_PATH set to: ${CMAKE_PREFIX_PATH}")
+elseif(DEFINED ENV{CONDA_PREFIX})
+    set(CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX};${CMAKE_PREFIX_PATH}")
+    set(CONDA_INCLUDE_DIRS "$ENV{CONDA_PREFIX}/include")
+    set(CONDA_LINK_DIRS "$ENV{CONDA_PREFIX}/lib")
+    message(VERBOSE "CUDF: Conda environment detected, CMAKE_PREFIX_PATH set to: ${CMAKE_PREFIX_PATH}")
+endif()
+
+# Add Conda library paths if specified
+if(CONDA_LINK_DIRS)
+    target_link_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_LINK_DIRS}>")
+endif()
+
+# Add Conda include paths if specified
+if(CONDA_INCLUDE_DIRS)
+    target_include_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_INCLUDE_DIRS}>")
+endif()
+
 #################################################################################################
 # - CPM -----------------------------------------------------------------------------------------
 
@@ -67,8 +92,8 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 ####################################################################################################
 # - cudf -------------------------------------------------------------------------------------------
 
-CPMAddPackage(NAME  cudf
-        VERSION         "0.19.0"
+CPMFindPackage(NAME  cudf
+        VERSION         "0.19"
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
         GIT_TAG         branch-0.19
         GIT_SHALLOW     TRUE

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -82,20 +82,20 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 ####################################################################################################
 # - cudf -------------------------------------------------------------------------------------------
 
-CPMFindPackage(NAME  cudf
-        VERSION         "0.19.0"
-        GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-        GIT_TAG         branch-0.19
-        GIT_SHALLOW     TRUE
-        SOURCE_SUBDIR   cpp
-        OPTIONS         "BUILD_TESTS OFF"
-                        "BUILD_BENCHMARKS OFF"
-                        "ARROW_STATIC_LIB ON"
-                        "JITIFY_USE_CACHE ON"
-                        "CUDA_STATIC_RUNTIME ON"
-                        "DISABLE_DEPRECATION_WARNING ON"
-                        "AUTO_DETECT_CUDA_ARCHITECTURES ON"
-    )
+# CPMFindPackage(NAME  cudf
+#         VERSION         "0.19.0"
+#         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
+#         GIT_TAG         branch-0.19
+#         GIT_SHALLOW     TRUE
+#         SOURCE_SUBDIR   cpp
+#         OPTIONS         "BUILD_TESTS OFF"
+#                         "BUILD_BENCHMARKS OFF"
+#                         "ARROW_STATIC_LIB ON"
+#                         "JITIFY_USE_CACHE ON"
+#                         "CUDA_STATIC_RUNTIME ON"
+#                         "DISABLE_DEPRECATION_WARNING ON"
+#                         "AUTO_DETECT_CUDA_ARCHITECTURES ON"
+#     )
 
 ######################################################################################################
 # - shareable_dataframes -----------------------------------------------------------------------------
@@ -110,13 +110,14 @@ if(BUILD_SHAREABLE_DATAFRAME)
                             "${CMAKE_CURRENT_SOURCE_DIR}/include"
                             )
 
-  target_link_libraries(shareable_dataframe
-                        cudf::cudf
-                        )
+  # target_link_libraries(shareable_dataframe
+  #                       cudf::cudf
+  #                       )
 
   # Add Conda library paths if specified
   if(CONDA_LINK_DIRS)
     target_link_directories(shareable_dataframe PUBLIC "$<BUILD_INTERFACE:${CONDA_LINK_DIRS}>")
+    target_link_libraries(shareable_dataframe cudf)
   endif()
 
   # Add Conda include paths if specified

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -145,7 +145,6 @@ if(BUILD_SHAREABLE_DATAFRAME)
 
   target_link_libraries(shareable_dataframe
                         cudf
-                        rmm
                         )
 
 endif()

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -129,6 +129,8 @@ if(BUILD_SHAREABLE_DATAFRAME)
 
   target_include_directories(shareable_dataframe PRIVATE 
                             "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                            "${LIBCUDACXX_INCLUDE_DIR}"
+                            "${LIBCXX_INCLUDE_DIR}"
                             )
 
   # Add Conda library paths if specified

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -82,20 +82,20 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 ####################################################################################################
 # - cudf -------------------------------------------------------------------------------------------
 
-CPMFindPackage(NAME  cudf
-        VERSION         "0.19.0"
-        GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-        GIT_TAG         branch-0.19
-        GIT_SHALLOW     TRUE
-        SOURCE_SUBDIR   cpp
-        OPTIONS         "BUILD_TESTS OFF"
-                        "BUILD_BENCHMARKS OFF"
-                        "ARROW_STATIC_LIB ON"
-                        "JITIFY_USE_CACHE ON"
-                        "CUDA_STATIC_RUNTIME OFF"
-                        "DISABLE_DEPRECATION_WARNING ON"
-                        "AUTO_DETECT_CUDA_ARCHITECTURES ON"
-    )
+# CPMFindPackage(NAME  cudf
+#         VERSION         "0.19.0"
+#         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
+#         GIT_TAG         branch-0.19
+#         GIT_SHALLOW     TRUE
+#         SOURCE_SUBDIR   cpp
+#         OPTIONS         "BUILD_TESTS OFF"
+#                         "BUILD_BENCHMARKS OFF"
+#                         "ARROW_STATIC_LIB ON"
+#                         "JITIFY_USE_CACHE ON"
+#                         "CUDA_STATIC_RUNTIME OFF"
+#                         "DISABLE_DEPRECATION_WARNING ON"
+#                         "AUTO_DETECT_CUDA_ARCHITECTURES ON"
+#     )
 
 ######################################################################################################
 # - shareable_dataframes -----------------------------------------------------------------------------
@@ -121,7 +121,8 @@ if(BUILD_SHAREABLE_DATAFRAME)
   endif()
 
   target_link_libraries(shareable_dataframe
-                        cudf::cudf
+                        cudf
+                        rmm
                         )
 
 endif()

--- a/shareable-dataframes/cpp/CMakeLists.txt
+++ b/shareable-dataframes/cpp/CMakeLists.txt
@@ -131,9 +131,9 @@ endif()
 # ###################################################################################################
 # # - library paths ---------------------------------------------------------------------------------
 
-# link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
-#                  "${CMAKE_BINARY_DIR}/lib"
-#                  "${CMAKE_BINARY_DIR}")
+link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
+                 "${CMAKE_BINARY_DIR}/lib"
+                 "${CMAKE_BINARY_DIR}")
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------


### PR DESCRIPTION
To significantly cut down container build times the libs/headers for libcudf are pulled from the Anaconda nightly repos.