### PR TITLE
Add missing nvs_udf.hpp

### DIFF
--- a/nvs_udf.hpp
+++ b/nvs_udf.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
+
+#include <string>
+
+std::unique_ptr<cudf::column> process_udf(std::string udf,
+                                          std::string udf_name,
+                                          cudf::size_type size,
+                                          std::vector<cudf::column_view> input,
+                                          size_t heap_size = 1073741824);


### PR DESCRIPTION
This header provides C++ declarations usable by a cython interface.