### PR TITLE
Remove defaults channel

### DIFF
--- a/rapids_triton_example/Dockerfile
+++ b/rapids_triton_example/Dockerfile
@@ -6,7 +6,7 @@ RUN cd /opt/nvidia && wget https://repo.continuum.io/miniconda/Miniconda3-latest
 ENV PATH="/root/miniconda3/bin:$PATH"
 RUN conda init bash \ 
      && . ~/.bashrc \ 
-     && conda create -n rapids-0.20  -c rapidsai-nightly -c nvidia -c conda-forge -c defaults rapids=0.20 python=3.8 cudatoolkit=11.2 
+     && conda create -n rapids-0.20  -c rapidsai-nightly -c nvidia -c conda-forge rapids=0.20 python=3.8 cudatoolkit=11.2 
 
 
 COPY ./entrypoint.sh ./entrypoint.sh

--- a/shareable-dataframes/conda/shareable_dataframes.yml
+++ b/shareable-dataframes/conda/shareable_dataframes.yml
@@ -4,7 +4,6 @@ channels:
   - nvidia
   - rapidsai-nightly
   - conda-forge
-  - defaults
 dependencies:
   - cudf=21.06
   - rmm=21.06

--- a/strings_udf/conda/strings_udf.yml
+++ b/strings_udf/conda/strings_udf.yml
@@ -4,7 +4,6 @@ channels:
   - nvidia
   - rapidsai-nightly
   - conda-forge
-  - defaults
 dependencies:
   - cudf=21.08
   - rmm=21.08


### PR DESCRIPTION
For legal reasons, we should not use the `defaults` channel.