### PR TITLE
Update Dockerfile to use cudf 21.10 from RapidsAI nightly

### DIFF
--- a/rapids_triton_example/Dockerfile
+++ b/rapids_triton_example/Dockerfile
@@ -6,7 +6,7 @@ RUN cd /opt/nvidia && wget https://repo.continuum.io/miniconda/Miniconda3-latest
 ENV PATH="/root/miniconda3/bin:$PATH"
 RUN conda init bash \ 
      && . ~/.bashrc \ 
-     && conda create -n rapids-0.20  -c rapidsai-nightly -c nvidia -c conda-forge rapids=0.20 python=3.8 cudatoolkit=11.2 
+     && conda create -n rapids -c rapidsai-nightly -c nvidia -c conda-forge cudf python=3.8 cudatoolkit=11.2 
 
 
 COPY ./entrypoint.sh ./entrypoint.sh

--- a/rapids_triton_example/entrypoint.sh
+++ b/rapids_triton_example/entrypoint.sh
@@ -4,7 +4,7 @@
 . /root/miniconda3/etc/profile.d/conda.sh
 
 # activate the environment
-conda activate rapids-0.20
+conda activate rapids
 
 # exec the cmd/command in this process, making it pid 1
 exec "$@"


### PR DESCRIPTION
This example is currently using cudf-0.20 which is causing issues while building due to conda conflicts.